### PR TITLE
Built in pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Here are two useful shortcuts for programming in R:
             "command": "text-shortcuts:insert-text",
             "args": {
                 "kernel": "ir",
-                "text": "%>%",
+                "text": "|>",
                 "autoPad": true
             },
             "keys": ["Accel Shift M"],
@@ -92,7 +92,7 @@ Identifies the keyboard shortcut as a text shortcut that is intercepted by this 
     ...
     "args": {
         "kernel": "ir",
-        "text": "%>%",
+        "text": "|>",
         "autoPad": true
     }
     ...

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -7,7 +7,7 @@
             "command": "text-shortcuts:insert-text",
             "args": {
                 "kernel": "ir",
-                "text": "%>%",
+                "text": "|>",
                 "autoPad": true
             },
             "keys": ["Accel Shift M"],

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -8,7 +8,7 @@ describe("getPaddedTextToInsert", () => {
         "The quick brown fox jumps over the lazy dog." +
         "\nThis is line two." +
         "\nThis is line three.";
-    const textToInsert = "%>%";
+    const textToInsert = "|>";
     const textToInsertLeftPadded = ` ${textToInsert}`;
     const textToInsertRightPadded = `${textToInsert} `;
     const textToInsertPadded = ` ${textToInsert} `;


### PR DESCRIPTION
@techrah - R 4.1 introduced a built-in pipe operator, `|>`, and we are going to use it in our data science teaching at UBC. This pull request is to change your pipe plugin that maps `Shift` +  `Command` + `M` to `%>%` to mapping `Shift` +  `Command` + `M` to `|>` (the built-in pipe). 

If you are not interested in making this change, I completely understand. I have forked the repo and created another package that does this. However, since yours is more widely known and used, I thought I would suggest this change in case you are interested!

Thanks again for making this super useful plugin!